### PR TITLE
Integration of Apache ODE into OpenTOSCA

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Wait a few seconds, then open the [OpenTOSCA user interface](http://localhost:80
 | OpenTOSCA Container API | http://localhost:1337 | [Link](https://github.com/OpenTOSCA/container) | [Link](https://hub.docker.com/r/opentosca/container) |
 | OpenTOSCA Container Repository | http://localhost:8081 | [Link](https://github.com/OpenTOSCA/winery) | [Link](https://hub.docker.com/r/opentosca/winery) |
 | OpenTOSCA Modelling (Eclipse Winery™) | http://localhost:8080 | [Link](https://github.com/OpenTOSCA/winery) | [Link](https://hub.docker.com/r/opentosca/winery) |
-| Plan Engine (WSO2 BPS) | http://localhost:9763 (user: `admin`, password: `admin`) | [Link](https://github.com/OpenTOSCA/engine-plan) | [Link](https://hub.docker.com/r/opentosca/engine-plan) |
-| IA Engine (Apache Tomcat) | http://localhost:8090/manager (user: `admin`, password: `admin`) | [Link](https://github.com/OpenTOSCA/engine-ia) | [Link](https://hub.docker.com/r/opentosca/engine-ia) |
+| Plan Engine (WSO2 BPS) | http://localhost:9763<br>(user: `admin`, password: `admin`) | [Link](https://github.com/OpenTOSCA/engine-plan) | [Link](https://hub.docker.com/r/opentosca/engine-plan) |
+| IA Engine (Apache Tomcat) | http://localhost:8090/manager<br>(user: `admin`, password: `admin`) | [Link](https://github.com/OpenTOSCA/engine-ia) | [Link](https://hub.docker.com/r/opentosca/engine-ia) |
 
 Have fun!
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Wait a few seconds, then open the [OpenTOSCA user interface](http://localhost:80
 | OpenTOSCA Component | URL | GitHub | Docker Hub |
 |:------------------- |:--- |:------ |:---------- |
 | OpenTOSCA UI | http://localhost:8088 | [Link](https://github.com/OpenTOSCA/ui) | [Link](https://hub.docker.com/r/opentosca/ui) |
+| OpenTOSCA Modelling (Eclipse Winery™) | http://localhost:8080 | [Link](https://github.com/OpenTOSCA/winery) | [Link](https://hub.docker.com/r/opentosca/winery) |
 | OpenTOSCA Container API | http://localhost:1337 | [Link](https://github.com/OpenTOSCA/container) | [Link](https://hub.docker.com/r/opentosca/container) |
 | OpenTOSCA Container Repository | http://localhost:8081 | [Link](https://github.com/OpenTOSCA/winery) | [Link](https://hub.docker.com/r/opentosca/winery) |
-| OpenTOSCA Modelling (Eclipse Winery™) | http://localhost:8080 | [Link](https://github.com/OpenTOSCA/winery) | [Link](https://hub.docker.com/r/opentosca/winery) |
 | Plan Engine (WSO2 BPS) | http://localhost:9763<br>(user: `admin`, password: `admin`) | [Link](https://github.com/OpenTOSCA/engine-plan) | [Link](https://hub.docker.com/r/opentosca/engine-plan) |
 | IA Engine (Apache Tomcat) | http://localhost:8090/manager<br>(user: `admin`, password: `admin`) | [Link](https://github.com/OpenTOSCA/engine-ia) | [Link](https://hub.docker.com/r/opentosca/engine-ia) |
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Wait a few seconds, then open the [OpenTOSCA user interface](http://localhost:80
 | OpenTOSCA Component | URL | GitHub | Docker Hub |
 |:------------------- |:--- |:------ |:---------- |
 | OpenTOSCA UI | http://localhost:8088 | [Link](https://github.com/OpenTOSCA/ui) | [Link](https://hub.docker.com/r/opentosca/ui) |
-| OpenTOSCA Modelling (Eclipse Winery™) | http://localhost:8080 | [Link](https://github.com/OpenTOSCA/winery) | [Link](https://hub.docker.com/r/opentosca/winery) |
+| OpenTOSCA Modelling (Eclipse Winery) | http://localhost:8080 | [Link](https://github.com/OpenTOSCA/winery) | [Link](https://hub.docker.com/r/opentosca/winery) |
 | OpenTOSCA Container API | http://localhost:1337 | [Link](https://github.com/OpenTOSCA/container) | [Link](https://hub.docker.com/r/opentosca/container) |
 | OpenTOSCA Container Repository | http://localhost:8081 | [Link](https://github.com/OpenTOSCA/winery) | [Link](https://hub.docker.com/r/opentosca/winery) |
 | Plan Engine (WSO2 BPS) | http://localhost:9763<br>(user: `admin`, password: `admin`) | [Link](https://github.com/OpenTOSCA/engine-plan) | [Link](https://hub.docker.com/r/opentosca/engine-plan) |

--- a/docker-compose-BPS.yml
+++ b/docker-compose-BPS.yml
@@ -14,6 +14,7 @@ services:
       - ENGINE_PLAN_SERVICES_URL=http://engine-plan:9763/services
       - ENGINE_PLAN_USER_NAME=admin
       - ENGINE_PLAN_PWD=admin
+      - CONTAINER_JAVA_OPTS=
     networks:
       - opentosca
   container-repository:

--- a/docker-compose-BPS.yml
+++ b/docker-compose-BPS.yml
@@ -9,11 +9,11 @@ services:
       - CONTAINER_REPOSITORY_HOSTNAME=container-repository
       - ENGINE_IA_HOSTNAME=engine-ia
       - ENGINE_PLAN_HOSTNAME=engine-plan
-      - ENGINE_PLAN=ODE # Change to "BPS" to use WSO2 BPS as plan engine
-      - ENGINE_PLAN_ROOT_URL=http://engine-plan:9763/ode # Change value to "https://engine-plan:9443" when using BPS as plan engine
-      - ENGINE_PLAN_SERVICES_URL=http://engine-plan:9763/ode/processes # Change value to "http://engine-plan:9763/services" when using BPS as plan engine
-      #- ENGINE_PLAN_USER_NAME=admin # Uncomment when using BPS as plan engine
-      #- ENGINE_PLAN_PWD=admin # Uncomment when using BPS as plan engine
+      - ENGINE_PLAN=BPS
+      - ENGINE_PLAN_ROOT_URL=https://engine-plan:9443
+      - ENGINE_PLAN_SERVICES_URL=http://engine-plan:9763/services
+      - ENGINE_PLAN_USER_NAME=admin
+      - ENGINE_PLAN_PWD=admin
     networks:
       - opentosca
   container-repository:
@@ -31,9 +31,9 @@ services:
     networks:
       - opentosca
   engine-plan:
-    image: opentosca/engine-plan-ode # Change to "opentosca/engine-plan" to use WSO2 BPS as plan engine
+    image: opentosca/engine-plan # Change to "opentosca/engine-plan" to use WSO2 BPS as plan engine
     ports:
-      #- '9443:9443' # Uncomment when using BPS as plan engine
+      - '9443:9443' # Add the https port when using BPS as plan engine
       - '9763:9763' # http
     environment:
       - ENGINE_PLAN_HOSTNAME=engine-plan
@@ -43,15 +43,7 @@ services:
   engine-ia:
     image: opentosca/engine-ia
     ports:
-      - '8090:8080'
-    networks:
-      - opentosca
-  winery:
-    image: opentosca/winery
-    ports:
       - '8080:8080'
-    # volumes:
-    #   - <path on host system>:/var/opentosca/repository
     networks:
       - opentosca
   dind:
@@ -67,6 +59,14 @@ services:
       - '9990-9999:9990-9999' # dind
     # volumes:
     #   - '/var/run/docker.sock:/var/run/docker.sock'
+    networks:
+      - opentosca
+  winery:
+    image: opentosca/winery
+    ports:
+      - '8090:8080'
+    # volumes:
+    #   - <path on host system>:/var/opentosca/repository
     networks:
       - opentosca
 networks:

--- a/docker-compose-BPS.yml
+++ b/docker-compose-BPS.yml
@@ -32,9 +32,9 @@ services:
     networks:
       - opentosca
   engine-plan:
-    image: opentosca/engine-plan # Change to "opentosca/engine-plan" to use WSO2 BPS as plan engine
+    image: opentosca/bps
     ports:
-      - '9443:9443' # Add the https port when using BPS as plan engine
+      - '9443:9443' # https
       - '9763:9763' # http
     environment:
       - ENGINE_PLAN_HOSTNAME=engine-plan

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,20 +1,29 @@
 version: '2'
 services:
   container:
-    image: opentosca/container-dev
+    image: opentosca/container
     ports:
       - '1337:1337'
       - '8001:8001' # Expose JAVA remote debugging port
     environment:
-      - CONTAINER_HOSTNAME=container
-      - CONTAINER_REPOSITORY_HOSTNAME=container-repository
-      - ENGINE_IA_HOSTNAME=engine-ia
-      - ENGINE_PLAN_HOSTNAME=engine-plan
-      - ENGINE_PLAN=ODE # Change to "BPS" to use WSO2 BPS as plan engine
-      - ENGINE_PLAN_ROOT_URL=http://engine-plan:9763/ode # Change value to "https://engine-plan:9443" when using BPS as plan engine
-      - ENGINE_PLAN_SERVICES_URL=http://engine-plan:9763/ode/processes # Change value to "http://engine-plan:9763/services" when using BPS as plan engine
-      #- ENGINE_PLAN_USER_NAME=admin # Uncomment when using BPS as plan engine
-      #- ENGINE_PLAN_PWD=admin # Uncomment when using BPS as plan engine
+      CONTAINER_HOSTNAME: container
+      CONTAINER_REPOSITORY_HOSTNAME: container-repository
+      ENGINE_IA_HOSTNAME: engine-ia
+      ENGINE_PLAN_HOSTNAME: engine-plan
+      # Change to "BPS" to use WSO2 BPS as plan engine
+      ENGINE_PLAN: ODE
+      # Change value to "https://engine-plan:9443" when using BPS as plan engine
+      ENGINE_PLAN_ROOT_URL: http://engine-plan:9763/ode
+      # Change value to "http://engine-plan:9763/services" when using BPS as plan engine
+      ENGINE_PLAN_SERVICES_URL: http://engine-plan:9763/ode/processes
+      # Uncomment when using BPS as plan engine
+      # ENGINE_PLAN_USER_NAME: admin
+      # Uncomment when using BPS as plan engine
+      # ENGINE_PLAN_PWD: admin
+      # Add remote debugging options to OpenTOSCA.ini file (options need to be on separate lines)
+      CONTAINER_JAVA_OPTS: |-
+        -Xdebug
+        -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=n
     networks:
       - opentosca
   container-repository:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -41,7 +41,7 @@ services:
     networks:
       - opentosca
   engine-plan:
-    image: opentosca/engine-plan-ode # Change to "opentosca/engine-plan" to use WSO2 BPS as plan engine
+    image: opentosca/ode # Change to "opentosca/bps" to use WSO2 BPS as plan engine
     ports:
       #- '9443:9443' # Uncomment when using BPS as plan engine
       - '9763:9763' # http

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,9 +1,10 @@
 version: '2'
 services:
   container:
-    image: opentosca/container
+    image: opentosca/container-dev
     ports:
       - '1337:1337'
+      - '8001:8001' # Expose JAVA remote debugging port
     environment:
       - CONTAINER_HOSTNAME=container
       - CONTAINER_REPOSITORY_HOSTNAME=container-repository
@@ -35,23 +36,17 @@ services:
     ports:
       #- '9443:9443' # Uncomment when using BPS as plan engine
       - '9763:9763' # http
+      - '5555:8000' # Remote debugging port
     environment:
       - ENGINE_PLAN_HOSTNAME=engine-plan
       - ENGINE_PLAN_PORT=9763
+      - JAVA_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n # Enable remote debugging of Apache ODE
     networks:
       - opentosca
   engine-ia:
     image: opentosca/engine-ia
     ports:
-      - '8090:8080'
-    networks:
-      - opentosca
-  winery:
-    image: opentosca/winery
-    ports:
       - '8080:8080'
-    # volumes:
-    #   - <path on host system>:/var/opentosca/repository
     networks:
       - opentosca
   dind:
@@ -67,6 +62,14 @@ services:
       - '9990-9999:9990-9999' # dind
     # volumes:
     #   - '/var/run/docker.sock:/var/run/docker.sock'
+    networks:
+      - opentosca
+  winery:
+    image: opentosca/winery
+    ports:
+      - '8090:8080'
+    # volumes:
+    #   - <path on host system>:/var/opentosca/repository
     networks:
       - opentosca
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ENGINE_PLAN_SERVICES_URL=http://engine-plan:9763/ode/processes # Change value to "http://engine-plan:9763/services" when using BPS as plan engine
       #- ENGINE_PLAN_USER_NAME=admin # Uncomment when using BPS as plan engine
       #- ENGINE_PLAN_PWD=admin # Uncomment when using BPS as plan engine
+      - CONTAINER_JAVA_OPTS=
     networks:
       - opentosca
   container-repository:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,9 @@ services:
     networks:
       - opentosca
   engine-plan:
-    image: opentosca/engine-plan-ode # Change to "opentosca/engine-plan" to use WSO2 BPS as plan engine
+    image: opentosca/ode # Change to "opentosca/bps" to use WSO2 BPS as plan engine
     ports:
-      #- '9443:9443' # Uncomment when using BPS as plan engine
+      #- '9443:9443' # https, uncomment when using BPS as plan engine
       - '9763:9763' # http
     environment:
       - ENGINE_PLAN_HOSTNAME=engine-plan


### PR DESCRIPTION
#### Short Description
Updated docker-compose files using Apache ODE as plan engine.

#### Proposed Changes
  * Updated docker-compose.yml so that it uses Apache ODE as default plan engine.
  * Added a separate compose file (docker-compose-BPS.yml) for using WSO2 BPS as plan engine.
  * Added a separate compose file (docker-compose-dev.yml) which allows remote debugging of Apache ODE and the OpenTOSCA container.