### PR TITLE
Change the default port for the container-repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,14 @@
 
 The fastest way to get started is using [Docker Compose](https://docs.docker.com/compose/):
 
-    docker-compose up
+* Add your publicly available FQDN or IP address to the `PUBLIC_HOSTNAME` variable in the `.env` file
+* Execute the following command:
 
-Wait a few seconds, then open the [OpenTOSCA user interface](http://localhost:8088).
+  ```shell
+  docker-compose up
+  ```
+
+Wait a few seconds, then open the [OpenTOSCA user interface](http://localhost).
 
 | OpenTOSCA Component | URL | GitHub | Docker Hub |
 |:------------------- |:--- |:------ |:---------- |
@@ -26,6 +31,7 @@ Wait a few seconds, then open the [OpenTOSCA user interface](http://localhost:80
 * `1337`
 * `8080-8088`
 * `8090`
+* `8091`
 * `8092`
 * `9763`
 * `1883`
@@ -34,8 +40,6 @@ Wait a few seconds, then open the [OpenTOSCA user interface](http://localhost:80
 > It is recommended that your host or virtual machine has at least 4GB of memory.
 
 **NOTE:** Please check the [Docker Daemon Settings](#docker-daemon-settings)
-
-**NOTE:** In an optimal setup `localhost` should be replaced by a publicly available Fully-Qualified Domain Name or IP address directly in the `.env` file.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       ENGINE_PLAN_BPMN: Camunda
       ENGINE_PLAN_BPMN_ROOT_URL: http://engine-plan-bpmn:8080/engine-rest
       CONTAINER_REPOSITORY_HOSTNAME: container-repository
-      CONTAINER_REPOSITORY_PORT: 8091
+      CONTAINER_REPOSITORY_PORT: 8080
       CONTAINER_DEPLOYMENT_TESTS: 'false'
       CONTAINER_JAVA_OPTS: ''
       COLLABORATION_MODE: 'false'


### PR DESCRIPTION
@miwurster: As many people have problems due to "connection refused" errors when the container uploads the CSAR to the container-repository I would suggest changing the port.
Currently you must either change "CONTAINER_REPOSITORY_HOSTNAME" to your IP and use 8091 as external port or "CONTAINER_REPOSITORY_PORT" to 8080 to use the internal port.
Otherwise we should update the doc and clearly state that the IP has to be updated before running the compose file.
What´s your opinion?