### PR TITLE
logging using loki and grafana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 .env
 docker-compose.override.yml
+.idea

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ A more detailed overview can be found in the [docs folder](./docs/container-over
 * `9763`
 * `1883`
 * `9000` (optional)
+* `3000` (optional grafana server)
+* `3100` (optional loki server)
 
 > It is recommended that your host or virtual machine has at least 4GB of memory.
 
@@ -72,6 +74,7 @@ How-Tos explaining how to realize specific scenarios can be found in [docs/advan
 * [How to debug components running inside the environment](./docs/advanced-how-to.md#how-to-debug-components-running-inside-the-environment)
 * [How to clone a **private** TOSCA definitions repository to be used with Winery](./docs/advanced-how-to.md#how-to-clone-a-private-tosca-definitions-repository-to-be-used-with-winery)
 * [How to extend Winery's JVM Heap Size](./docs/advanced-how-to.md#how-to-extend-winery's-jvm-heap-size)
+* [How to access logs using the Browser](./docs/advanced-how-to.md#how-to-access-logs-using-the-browser)
 
 
 ## Tips and Tricks

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -1,0 +1,61 @@
+version: '3'
+
+x-logging:
+  &logging
+  driver: loki
+  options:
+    loki-url: http://${PUBLIC_HOSTNAME}:3100/loki/api/v1/push
+
+services:
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - opentosca
+    logging: *logging
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./logging/grafana.ini:/etc/grafana/grafana.ini
+      - ./logging/loki.yaml:/etc/grafana/provisioning/datasources/loki.yaml
+    networks:
+      - opentosca
+    logging: *logging
+
+  container:
+    logging: *logging
+
+  container-repository:
+    logging: *logging
+
+  ui:
+    logging: *logging
+
+  bowie:
+    logging: *logging
+
+  engine-plan:
+    logging: *logging
+
+  engine-plan-bpmn:
+    logging: *logging
+
+  engine-ia-jdk8:
+    logging: *logging
+
+  engine-ia-jdk17:
+    logging: *logging
+
+  winery:
+    logging: *logging
+
+  dind:
+    logging: *logging
+
+  proxy:
+    logging: *logging

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -26,36 +26,60 @@ services:
     networks:
       - opentosca
     logging: *logging
+    depends_on:
+      - loki
 
   container:
     logging: *logging
+    depends_on:
+      - loki
 
   container-repository:
     logging: *logging
+    depends_on:
+      - loki
 
   ui:
     logging: *logging
+    depends_on:
+      - loki
 
   bowie:
     logging: *logging
+    depends_on:
+      - loki
 
   engine-plan:
     logging: *logging
+    depends_on:
+      - loki
 
   engine-plan-bpmn:
     logging: *logging
+    depends_on:
+      - loki
 
   engine-ia-jdk8:
     logging: *logging
+    depends_on:
+      - loki
 
   engine-ia-jdk17:
     logging: *logging
+    depends_on:
+      - loki
 
   winery:
     logging: *logging
+    depends_on:
+      - loki
 
   dind:
     logging: *logging
+    depends_on:
+      - loki
 
   proxy:
     logging: *logging
+    depends_on:
+      - loki

--- a/docs/advanced-how-to.md
+++ b/docs/advanced-how-to.md
@@ -114,3 +114,28 @@ You can adjust Winery's JVM heap size by setting a respective environment variab
 * **Note:** Make sure the hosting VM has enough capacity
 * Start the environment as usual: `docker-compose up -d`
 
+
+## How to access Logs using the Browser
+
+Its is possible to start a loki and grafana server to access docker logs in the browser.
+Therefore, you must install the loki docker driver as follows and extend the default docker-compose file with the logging configurations.
+
+```
+# Install loki docker driver
+docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
+
+# Start next to usual services a loki and grafana server
+docker-compose -f docker-compose.yml -f docker-compose.logging.yml up -d
+```
+
+The logs can be accessed at `http://${PUBLIC_HOSTNAME}:3000/explorer`.
+The following exemplary query displays the container logs.
+```
+{compose_service="container"}
+```
+
+Some useful links:
+- [LogQL: Log query language](https://grafana.com/docs/loki/latest/logql)
+- [Grafana Labs Explore Docs](https://grafana.com/docs/grafana/latest/explore)
+
+Note, logs of the docker containers inside dind are currently not accessible.

--- a/docs/advanced-how-to.md
+++ b/docs/advanced-how-to.md
@@ -129,7 +129,7 @@ docker-compose -f docker-compose.yml -f docker-compose.logging.yml up -d
 ```
 
 The logs can be accessed at `http://${PUBLIC_HOSTNAME}:3000/explore`.
-The following exemplary searches for `ready to use` in the OpenTOSCA Container logs.
+The following exemplary query searches for `ready to use` in the OpenTOSCA Container logs.
 ```
 {compose_service="container"} |= "ready to use"
 ```

--- a/docs/advanced-how-to.md
+++ b/docs/advanced-how-to.md
@@ -128,7 +128,7 @@ docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all
 docker-compose -f docker-compose.yml -f docker-compose.logging.yml up -d
 ```
 
-The logs can be accessed at `http://${PUBLIC_HOSTNAME}:3000/explorer`.
+The logs can be accessed at `http://${PUBLIC_HOSTNAME}:3000/explore`.
 The following exemplary query displays the container logs.
 ```
 {compose_service="container"}

--- a/docs/advanced-how-to.md
+++ b/docs/advanced-how-to.md
@@ -117,21 +117,21 @@ You can adjust Winery's JVM heap size by setting a respective environment variab
 
 ## How to access Logs using the Browser
 
-Its is possible to start a loki and grafana server to access docker logs in the browser.
+It is possible to start a loki and grafana server to access docker logs in the browser.
 Therefore, you must install the loki docker driver as follows and extend the default docker-compose file with the logging configurations.
 
 ```
 # Install loki docker driver
 docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
 
-# Start next to usual services a loki and grafana server
+# Start services in background along with loki and grafana server
 docker-compose -f docker-compose.yml -f docker-compose.logging.yml up -d
 ```
 
 The logs can be accessed at `http://${PUBLIC_HOSTNAME}:3000/explore`.
-The following exemplary query displays the container logs.
+The following exemplary searches for `ready to use` in the OpenTOSCA Container logs.
 ```
-{compose_service="container"}
+{compose_service="container"} |= "ready to use"
 ```
 
 Some useful links:

--- a/logging/grafana.ini
+++ b/logging/grafana.ini
@@ -1,0 +1,3 @@
+[auth.anonymous]
+enabled = true
+org_role = Admin

--- a/logging/loki.yaml
+++ b/logging/loki.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    url: http://loki:3100
+    editable: true
+    isDefault: true


### PR DESCRIPTION
What

docker-compose to start loki and grafana server to access docker logs using the browser

Advantages
- easy access docker logs
- easy search
- download logs 

Disadvantages
- the loki docker driver must be installed
- confusing to always use -f during docker-compose calls