### PR TITLE
Update dind to officially maintained image

### DIFF
--- a/_docker-compose.override.yml
+++ b/_docker-compose.override.yml
@@ -27,14 +27,11 @@ services:
     environment:
       WINERY_REPOSITORY_URL: https://github.com/OpenTOSCA/tosca-definitions-public
   dind:
-    environment:
-      # University of Stuttgart internal DNS settings
-      - DOCKER_DAEMON_ARGS=--dns 129.69.211.1 --dns 129.69.215.5 -D
+    volumes:
+      # Enable University of Stuttgart internal DNS settings via corresponding config file
+      - ./resolv.conf:/etc/resolv.conf
     ports:
-      - '9990-9999:9990-9999'
       - '3306:3306'
-    # volumes:
-    #   - '/var/run/docker.sock:/var/run/docker.sock'
   tops:
     image: opentosca/tops:latest
     ports:

--- a/docker-compose.override.yml2
+++ b/docker-compose.override.yml2
@@ -14,10 +14,6 @@ services:
     # volumes:
     #   - <path on host system>:/var/opentosca/repository
   dind:
-    environment:
-      # University of Stuttgart internal DNS settings
-      - DOCKER_DAEMON_ARGS=--dns 129.69.211.1 --dns 129.69.215.5 -D
-    ports:
-      - '9990-9999:9990-9999'
-    # volumes:
-    #   - '/var/run/docker.sock:/var/run/docker.sock'
+    volumes:
+      # Enable University of Stuttgart internal DNS settings via corresponding config file
+      - ./resolv.conf:/etc/resolv.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,11 +88,10 @@ services:
     networks:
       - opentosca
   dind:
-    image: jpetazzo/dind:latest
+    image: docker:20.10-dind
     privileged: true
     environment:
-      - PORT=2375
-      - DOCKER_DAEMON_ARGS=--dns 8.8.8.8 --dns 8.8.4.4 -D
+      - DOCKER_TLS_CERTDIR=
     networks:
       - opentosca
     ports: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - '4242:80'
     networks:
       - opentosca 
-  engine-plan:
+  engine-plan-bpel:
     image: opentosca/ode:latest
     ports:
       - '9763:9763' # http

--- a/resolv.conf
+++ b/resolv.conf
@@ -1,0 +1,3 @@
+#/etc/resolv.conf
+nameserver 29.69.211.1
+nameserver 129.69.215.5


### PR DESCRIPTION
Update outdated jpetazzo/dind container which leads to errors when starting on Macs with newer Docker engine versions with officially maintained image

- [ ] Test without DNS changes
- [ ] Test within university network with adapted DNS settings